### PR TITLE
vm_arm: remove unused attic variables

### DIFF
--- a/components/VM_Arm/configurations/vm.h
+++ b/components/VM_Arm/configurations/vm.h
@@ -92,9 +92,9 @@
         string linux_ram_base; \
         string linux_ram_paddr_base; \
         string linux_ram_size; \
-        string linux_ram_offset; \
+        string linux_ram_offset = "0"; /* obsolete */ \
         string dtb_addr; \
-        string initrd_max_size; \
+        string initrd_max_size = "-1"; /* obsolete */ \
         string initrd_addr; \
     } linux_address_config; \
     attribute { \

--- a/templates/seL4VMParameters.template.c
+++ b/templates/seL4VMParameters.template.c
@@ -41,9 +41,7 @@ const unsigned long entry_addr = /*? vm_address_config.get('ram_base') ?*/ + 0x8
 const unsigned long ram_base = /*? linux_address_config.get('linux_ram_base') ?*/;
 const unsigned long ram_paddr_base = /*? linux_address_config.get('linux_ram_paddr_base') ?*/;
 const unsigned long ram_size = /*? linux_address_config.get('linux_ram_size') ?*/;
-const unsigned long ram_offset = /*? linux_address_config.get('linux_ram_offset') ?*/;
 const unsigned long dtb_addr = /*? linux_address_config.get('dtb_addr') ?*/;
-const unsigned long initrd_max_size = /*? linux_address_config.get('initrd_max_size') ?*/;
 const unsigned long initrd_addr = /*? linux_address_config.get('initrd_addr') ?*/;
 
 #ifdef CONFIG_ARCH_AARCH64

--- a/templates/seL4VMParameters.template.h
+++ b/templates/seL4VMParameters.template.h
@@ -14,11 +14,6 @@ extern const unsigned long dtb_addr;
 extern const unsigned long initrd_addr;
 extern const unsigned long entry_addr;
 
-/*- if not configuration[me.name].get('vm_address_config') -*/
-extern const unsigned long initrd_max_size;
-extern const unsigned long ram_offset;
-/*- endif -*/
-
 extern const int provide_initrd;
 extern const int generate_dtb;
 extern const int provide_dtb;


### PR DESCRIPTION
Also set a dummy default configuration, so they don't have to be specified in new configurations files in case the deprecated config block linux_address_config is used.